### PR TITLE
Added custom build target in metallus config

### DIFF
--- a/metallus/containers/build.py
+++ b/metallus/containers/build.py
@@ -39,6 +39,9 @@ class BuildContainer(Container):
         if len(self.project.current_job.tests) > 0:
             env['TESTS'] = " ".join(self.project.tests)
 
+        if self.project.current_job.build_target:
+            env["BUILD_TARGET"] = self.project.current_job.build_target
+
         # TODO worry about the order of overrides here, branch env vars should
         # override job env vars
 

--- a/metallus/jobs.py
+++ b/metallus/jobs.py
@@ -16,6 +16,7 @@ class Job:
         self.environment = values.get('environment', {})
         self.build_depends = values.get('build_depends', [])
         self.build_depends_target = values.get('build_depends_target', None)
+        self.build_target = values.get('build_target', None)
         self.packages = values.get('packages', [])
         self.skip_tests = values.get('skip_tests', False)
         self.tests = values.get('tests', [])

--- a/metallus/scripts/make
+++ b/metallus/scripts/make
@@ -8,8 +8,12 @@ if [[ -n "$START_IN" ]]; then
   cd "$START_IN"
 fi
 
-make -e
+if [[ -n "$BUILD_TARGET" ]]; then
+  make -e "$BUILD_TARGET"
+else
+  make -e
+fi
 
 if [[ -n "$TESTS" ]]; then
-  make $TESTS
+  make "$TESTS"
 fi


### PR DESCRIPTION
- this allows you to specify a named target rather than defaulting to
  just `make -e`. if you add build_target: my-target to the job
  definition in the metallus.yml that will be called.
